### PR TITLE
use 'longest_match' with stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "traefik_crowdsec_bouncer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traefik_crowdsec_bouncer"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/bouncer.rs
+++ b/src/bouncer.rs
@@ -73,7 +73,7 @@ pub async fn authenticate(
                 let req_ip = Ipv4Addr::from_str(&req_ip_str);
                 match req_ip {
                     Ok(ip) => {
-                        if ipv4_table.exact_match(ip, 32).is_some() {
+                        if ipv4_table.longest_match(ip).is_some() {
                             forbidden_response(Some(req_ip_str))
                         } else {
                             allowed_response(Some(req_ip_str))

--- a/src/crowdsec.rs
+++ b/src/crowdsec.rs
@@ -11,7 +11,7 @@ use ip_network_table_deps_treebitmap::IpLookupTable;
 use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
-use crate::errors::{CrowdSecApiError};
+use crate::errors::CrowdSecApiError;
 use crate::types::{CacheAttributes, HealthStatus};
 use crate::utils::get_ip_and_subnet;
 


### PR DESCRIPTION
Since the stream can contain IP ranges, do not use `exact_match` but rather `longest_match`.